### PR TITLE
Fix hanami-action gem name, since it's been renamed

### DIFF
--- a/lib/hanami/minitest.rb
+++ b/lib/hanami/minitest.rb
@@ -44,7 +44,7 @@ module Hanami
         Hanami::CLI.after "generate operation", Commands::Generate::Operation
       end
 
-      if Hanami.bundled?("hanami-controller")
+      if Hanami.bundled?("hanami-action")
         Hanami::CLI.after "generate action", Commands::Generate::Action
       end
 


### PR DESCRIPTION
See: https://github.com/hanami/hanami-action/pull/507

Analogous hanami-rspec change https://github.com/hanami/hanami-rspec/pull/44