### PR TITLE
Generate test/support/mailers.rb

### DIFF
--- a/lib/hanami/minitest/commands.rb
+++ b/lib/hanami/minitest/commands.rb
@@ -15,6 +15,7 @@ module Hanami
           copy_support_db
           copy_support_features
           copy_support_operations
+          copy_support_mailers
           copy_support_requests
 
           generate_request_test
@@ -77,6 +78,15 @@ module Hanami
           fs.cp(
             fs.expand_path(fs.join("generators", "templates", "support_operations.rb"), __dir__),
             fs.expand_path(fs.join("test", "support", "operations.rb"))
+          )
+        end
+
+        def copy_support_mailers
+          return unless Hanami.bundled?("hanami-mailer")
+
+          fs.cp(
+            fs.expand_path(fs.join("generators", "templates", "support_mailers.rb"), __dir__),
+            fs.expand_path(fs.join("test", "support", "mailers.rb"))
           )
         end
 

--- a/lib/hanami/minitest/generators/mailer.rb
+++ b/lib/hanami/minitest/generators/mailer.rb
@@ -41,6 +41,8 @@ module Hanami
             header: ["# frozen_string_literal: true", "", 'require "test_helper"'],
             parent_class_name: "Hanami::Minitest::Test",
             body: <<~RUBY.lines(chomp: true)
+              include TestSupport::Mailers
+
               # Inspect the delivered message to assert on its contents:
               #
               # assert_equal ["recipient@example.com"], result.message.to

--- a/lib/hanami/minitest/generators/templates/support_mailers.rb
+++ b/lib/hanami/minitest/generators/templates/support_mailers.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Reset recorded mail deliveries between tests.
+#
+# In the test env, mail is delivered via a shared test delivery method, so recorded
+# deliveries accumulate across tests. Include this module in any test that sends mail
+# to start with a clean slate:
+#
+#   class Mailers::WelcomeTest < Hanami::Minitest::Test
+#     include TestSupport::Mailers
+#     # ...
+#   end
+module TestSupport
+  module Mailers
+    def setup
+      Hanami.app.with_slices.each do |slice|
+        next unless slice.key?("mailers.delivery_method")
+
+        slice["mailers.delivery_method"].clear
+      end
+
+      super
+    end
+  end
+end

--- a/test/unit/commands/generate/mailer_test.rb
+++ b/test/unit/commands/generate/mailer_test.rb
@@ -18,6 +18,8 @@ class Hanami::Minitest::Commands::Generate::MailerTest < ::Minitest::Test
         require "test_helper"
 
         class Bookshelf::Mailers::WelcomeTest < Hanami::Minitest::Test
+          include TestSupport::Mailers
+
           # Inspect the delivered message to assert on its contents:
           #
           # assert_equal ["recipient@example.com"], result.message.to

--- a/test/unit/commands/install_test.rb
+++ b/test/unit/commands/install_test.rb
@@ -15,7 +15,7 @@ class Hanami::Minitest::Commands::InstallTest < ::Minitest::Test
 
   def test_copies_all_test_support_files_with_hanami_db
     within_application_directory do
-      Hanami.stub(:bundled?, ->(gem) { gem == "hanami-db" }) do
+      Hanami.stub(:bundled?, ->(gem) { ["hanami-db", "hanami-mailer"].include?(gem) }) do
         @subject.call({})
       end
 
@@ -186,6 +186,36 @@ class Hanami::Minitest::Commands::InstallTest < ::Minitest::Test
       EXPECTED
       assert_equal support_operations, @fs.read("test/support/operations.rb")
 
+      # test/support/mailers.rb
+      support_mailers = <<~EXPECTED
+        # frozen_string_literal: true
+
+        # Reset recorded mail deliveries between tests.
+        #
+        # In the test env, mail is delivered via a shared test delivery method, so recorded
+        # deliveries accumulate across tests. Include this module in any test that sends mail
+        # to start with a clean slate:
+        #
+        #   class Mailers::WelcomeTest < Hanami::Minitest::Test
+        #     include TestSupport::Mailers
+        #     # ...
+        #   end
+        module TestSupport
+          module Mailers
+            def setup
+              Hanami.app.with_slices.each do |slice|
+                next unless slice.key?("mailers.delivery_method")
+
+                slice["mailers.delivery_method"].clear
+              end
+
+              super
+            end
+          end
+        end
+      EXPECTED
+      assert_equal support_mailers, @fs.read("test/support/mailers.rb")
+
       # test/support/requests.rb
       support_requests = <<~EXPECTED
         # frozen_string_literal: true
@@ -234,6 +264,7 @@ class Hanami::Minitest::Commands::InstallTest < ::Minitest::Test
 
       refute @fs.exist?("test/support/db.rb")
       refute @fs.exist?("test/support/db/cleaning.rb")
+      refute @fs.exist?("test/support/mailers.rb")
     end
   end
 


### PR DESCRIPTION
When included, `TestSupport::Mailers` resets mail deliveries between tests. Include this module for the generated mailer tests.