### PR TITLE
Add workaround for RDoc causing JRuby failures

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,12 @@ gem "hanami-utils", github: "hanami/utils", branch: "main"
 gem "hanami-cli", github: "hanami/cli", branch: "main"
 gem "hanami", github: "hanami/hanami", branch: "main"
 
+# Work around RDoc/JRuby incompatibiltiy: rdoc 8 depends on rbs 4, whose native C extension can't
+# build on JRuby.
+#
+# Remove this once https://github.com/ruby/rdoc/issues/1746 is resolved.
+gem "rdoc", "< 8.0"
+
 group :tools do
   gem "debug", platform: :mri
 end


### PR DESCRIPTION
RDoc 8 depends on rbs 4, whose native C extension can't build on JRuby.

We can remove this once https://github.com/ruby/rdoc/issues/1746 is resolved.