### PR TITLE
Fix feature test DB cleaner issue

### DIFF
--- a/lib/hanami/minitest/generators/templates/support_features.rb
+++ b/lib/hanami/minitest/generators/templates/support_features.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-class Hanami::Minitest::FeatureTest
+class FeatureTest < Hanami::Minitest::FeatureTest
   # Add custom feature test helpers here.
 end

--- a/test/unit/commands/install_test.rb
+++ b/test/unit/commands/install_test.rb
@@ -163,7 +163,7 @@ class Hanami::Minitest::Commands::InstallTest < ::Minitest::Test
       support_features = <<~EXPECTED
         # frozen_string_literal: true
 
-        class Hanami::Minitest::FeatureTest
+        class FeatureTest < Hanami::Minitest::FeatureTest
           # Add custom feature test helpers here.
         end
       EXPECTED


### PR DESCRIPTION
The `test/support/db.rb` we generate includes this snippet to configure database cleaning: https://github.com/hanami/hanami-minitest/blob/01d09fc272e49bc780950734c87038671598d34e/lib/hanami/minitest/generators/templates/support_db.rb#L16-L18

That's _supposed_ to wire up the app's feature tests with automatic database cleaning support.

However, `FeatureTest` wasn't defined in `features.rb`: https://github.com/hanami/hanami-minitest/blob/01d09fc272e49bc780950734c87038671598d34e/lib/hanami/minitest/generators/templates/support_features.rb#L3-L5

So this effectively does nothing.

This changes fixes `features.rb` to define `FeatureTest` as the app's base feature test class, so that feature test database cleaning setup works as intended.

This also has the effect of making the code match the README, where it instructs users to inherit from `FeatureTest` when adding new feature tests.
