### PR TITLE
Generate the app's RequestTest class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Break Versioning](https://www.taoensso.com/break-ve
 
 ### Fixed
 
+- Generate `FeatureTest` and `RequestTest` classes so feature and request tests work as expected without configuration. (@mddelk in #9, #10)
+
 ### Security
 
 [Unreleased]: https://github.com/hanami/hanami-minitest/compare/v3.0.0...HEAD

--- a/lib/hanami/minitest/generators/templates/request.rb
+++ b/lib/hanami/minitest/generators/templates/request.rb
@@ -2,7 +2,7 @@
 
 require "test_helper"
 
-class RootTest < Hanami::Minitest::RequestTest
+class RootTest < RequestTest
   test "not found" do
     get "/"
 

--- a/lib/hanami/minitest/generators/templates/support_requests.rb
+++ b/lib/hanami/minitest/generators/templates/support_requests.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
-class Hanami::Minitest::RequestTest
+class RequestTest < Hanami::Minitest::RequestTest
   # Add custom request test helpers here.
 end

--- a/test/unit/commands/install_test.rb
+++ b/test/unit/commands/install_test.rb
@@ -216,7 +216,7 @@ class Hanami::Minitest::Commands::InstallTest < ::Minitest::Test
       support_requests = <<~EXPECTED
         # frozen_string_literal: true
 
-        class Hanami::Minitest::RequestTest
+        class RequestTest < Hanami::Minitest::RequestTest
           # Add custom request test helpers here.
         end
       EXPECTED
@@ -228,7 +228,7 @@ class Hanami::Minitest::Commands::InstallTest < ::Minitest::Test
 
         require "test_helper"
 
-        class RootTest < Hanami::Minitest::RequestTest
+        class RootTest < RequestTest
           test "not found" do
             get "/"
 


### PR DESCRIPTION
Update `test/support/requests.rb` to define a top-level `RequestTest` that the app's request tests can inherit from.

This makes the code match the README, where it instructs users to inherit from `RequestTest` when adding new request tests.

Alternatively, if we _do_ want folks to directly inherit from `Hanami::Minitest::RequestTest` when defining request tests, then we should update the README instead. Happy to go with that approach if we prefer it.